### PR TITLE
using env for interpreter location is insecure

### DIFF
--- a/S3fileshare.py
+++ b/S3fileshare.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/python3
 
 import logging
 import boto3


### PR DESCRIPTION
Change interpreter from 

`#!/usr/bin/env python3`

to

`#!/usr/bin/python3`

to discourage this usage. This can lead to security issues if misused.